### PR TITLE
fixes error when reading GPSLatitudeRef and GPSLongitudeRef

### DIFF
--- a/piexif/_load.py
+++ b/piexif/_load.py
@@ -154,6 +154,8 @@ class _ExifReader(object):
             if length > 4:
                 pointer = struct.unpack(self.endian_mark + "L", value)[0]
                 data = self.tiftag[pointer: pointer+length - 1]
+            elif length == 1:
+                data = value[0:length]
             else:
                 data = value[0: length - 1]
         elif t == TYPES.Short: # SHORT


### PR DESCRIPTION
This fixes a parsing error when loading exif data. The fix retains the GPSLatitudeRef and GPSLongitudeRef data. This is needed for decimal degree calculation. It is curretly lost.

Original PR https://github.com/hMatoba/Piexif/pull/133